### PR TITLE
Skip non-LTS Node.js versions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "node"
+        versions: [">=25, <26"]


### PR DESCRIPTION
## Summary
- Ignores Node 25.x (Current/unstable) in Dependabot Docker updates
- Will still pick up Node 26 when it becomes LTS (Oct 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)