### PR TITLE
Fix incorrect SHA for docker/build-push-action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816078c # v6.18.0
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary
- Corrects the pinned SHA for `docker/build-push-action@v6.18.0`
- All other action SHAs verified correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)