### PR TITLE
Give node user passwordless sudo access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,6 @@ RUN /home/node/.local/bin/uv python install 3.14
 COPY init-firewall.sh /usr/local/bin/
 USER root
 RUN chmod +x /usr/local/bin/init-firewall.sh && \
-  echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
-  chmod 0440 /etc/sudoers.d/node-firewall
+  echo "node ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/node && \
+  chmod 0440 /etc/sudoers.d/node
 USER node


### PR DESCRIPTION
## Summary
- Broadens sudoers from firewall-only to full passwordless sudo
- Standard practice for devcontainer images
- Needed for volume ownership (e.g. `chown` on mounted .venv volumes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)