### PR TITLE
Fix release drafter not showing unlabeled PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,8 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
+exclude-labels:
+  - "skip-changelog"
+
 categories:
   - title: "Breaking Changes"
     label: "breaking-change"


### PR DESCRIPTION
## Summary
- Add `exclude-labels: skip-changelog` so all PRs appear in release notes by default
- Only PRs explicitly labeled `skip-changelog` are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)