### PR TITLE
Add 1Password CLI to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,12 @@ RUN ARCH=$(dpkg --print-architecture) && \
   dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
   rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
 
+ARG OP_CLI_VERSION=2.32.1
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_CLI_VERSION}/op_linux_${ARCH}_v${OP_CLI_VERSION}.zip" && \
+  unzip "op_linux_${ARCH}_v${OP_CLI_VERSION}.zip" -d /usr/local/bin && \
+  rm "op_linux_${ARCH}_v${OP_CLI_VERSION}.zip"
+
 USER node
 
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global


### PR DESCRIPTION
## Summary
- Install 1Password CLI v2.32.1 directly from 1Password's official CDN
- Uses the same versioned `ARG` + architecture-aware download pattern as git-delta
- Avoids third-party devcontainer features for security-sensitive tooling — trust chain goes directly to 1Password

## Test plan
- [ ] Build the image and verify `op --version` returns `2.32.1`
- [ ] Verify on both amd64 and arm64 architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)