### PR TITLE
Rebase on devcontainers/javascript-node and add Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,18 +15,3 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "06:00"
-      timezone: "America/Los_Angeles"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
-    labels:
-      - "dependencies"
-    ignore:
-      - dependency-name: "node"
-        versions: [">=25, <26"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "github-actions": {
+    "enabled": false
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile[^/]*$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\nARG\\s+\\w+=(?<currentValue>[^\\s]+)"
+      ]
+    }
+  ],
+  "customDatasources": {
+    "one-password-cli": {
+      "defaultRegistryUrlTemplate": "https://app-updates.agilebits.com/check/1/0/CLI2/en/2000001/N",
+      "transformTemplates": [
+        "{\"releases\": [{\"version\": version}]}"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Rebase image** from `node:24` to `mcr.microsoft.com/devcontainers/javascript-node:4.0.8-24-bookworm`, which includes Node.js, zsh/Oh My Zsh, sudo, build-essential, and 40+ common dev utilities — eliminating ~15 redundant apt packages and the zsh-in-docker setup
- **Upgrade gh CLI** from Debian's outdated v2.23.0 (apt) to v2.86.0 (pinned GitHub release download)
- **Add Renovate** with regex custom manager to auto-track versioned tool ARGs and a custom datasource for 1Password CLI via the AgileBits update API
- **Move Docker FROM tracking** from Dependabot to Renovate

## What Renovate tracks

| Dependency | Version | Datasource |
|-----------|---------|-----------|
| devcontainers/javascript-node | `4.0.8-24-bookworm` | docker (built-in) |
| gh CLI | `2.86.0` | github-releases |
| git-delta | `0.18.2` | github-releases |
| 1Password CLI | `2.32.1` | custom (AgileBits API) |
| Python | `3.14.3` | python-version |

Node major version bumps (24→26) remain manual (~once/year).

## Setup required

After merging, install the [Mend Renovate GitHub App](https://github.com/apps/renovate) on this repo. It will detect `renovate.json` and begin opening version-bump PRs automatically.

## Test plan

- [ ] Build the image locally with `docker build .`
- [ ] Verify `node --version`, `gh --version`, `delta --version`, `op --version`, `python3 --version` inside the container
- [ ] Verify zsh starts with Oh My Zsh and fzf keybindings work
- [ ] Verify Claude Code is installed (`claude --version`)
- [ ] Install Renovate app and confirm it creates a Dependency Dashboard issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)